### PR TITLE
Fixed deprecated get item function call in word2vec predict

### DIFF
--- a/graph2vec/graph.py
+++ b/graph2vec/graph.py
@@ -403,7 +403,7 @@ class Node2Vec():
         # ints need to be str -_-
         if type(node_name) is not str:
             node_name = str(node_name)
-        return self.model[node_name]
+        return self.model.wv.__getitem__(node_name)
 
     def save(self, out_file):
         """


### PR DESCRIPTION
In the prediction function, I changed the following code to fix the deprecated function call

Original code:
> return self.model[node_name]

After modification
> return self.model.wv.__getitem__(node_name)